### PR TITLE
Add link to english calendar on english news page

### DIFF
--- a/src/components/News/index.js
+++ b/src/components/News/index.js
@@ -195,12 +195,10 @@ export const News = ({ location, lang, match }) => {
                         <Swedish>Exporterbar kalender</Swedish>
                       </Translate>
                     </h2>
-                    <a href="https://calypso.datasektionen.se/feeds/ical">
-                      <Translate>
-                        <English><a href="https://calypso.datasektionen.se/feeds/ical_en">Link to ical-calendar</a></English>
-                        <Swedish><a href="https://calypso.datasektionen.se/feeds/ical">Länk till ical-kalender</a></Swedish>
-                      </Translate>
-                    </a>
+                    <Translate>
+                      <English><a href="https://calypso.datasektionen.se/feeds/ical_en">Link to ical-calendar</a></English>
+                      <Swedish><a href="https://calypso.datasektionen.se/feeds/ical">Länk till ical-kalender</a></Swedish>
+                    </Translate>
                   </div>
                 </div>
               </div>

--- a/src/components/News/index.js
+++ b/src/components/News/index.js
@@ -197,8 +197,8 @@ export const News = ({ location, lang, match }) => {
                     </h2>
                     <a href="https://calypso.datasektionen.se/feeds/ical">
                       <Translate>
-                        <English>Link to ical-calendar</English>
-                        <Swedish>Länk till ical-kalender</Swedish>
+                        <English><a href="https://calypso.datasektionen.se/feeds/ical_en">Link to ical-calendar</a></English>
+                        <Swedish><a href="https://calypso.datasektionen.se/feeds/ical">Länk till ical-kalender</a></Swedish>
                       </Translate>
                     </a>
                   </div>


### PR DESCRIPTION
Adds a link to an english version of the event-ical-calendar for the english news page.

Should not be merged before [calypso#27](https://github.com/datasektionen/calypso/pull/27) is deployed.