### PR TITLE
Remove yellow text-shadow from title

### DIFF
--- a/src/components/Frontpage/Frontpage.module.css
+++ b/src/components/Frontpage/Frontpage.module.css
@@ -14,7 +14,7 @@
 .header .title .bold {
   font-size: 5em;
   font-weight: bolder;
-  text-shadow: -2px -2px #fcda02, 4px 4px #e83d84;
+  text-shadow: 4px 4px #EE2A7B;
   line-height: 1.3em;
   color: #fff;
   display: flex;


### PR DESCRIPTION
make the text shadow cerise strong

edit:
Det skulle altså se ut så här:
![image](https://user-images.githubusercontent.com/52171526/143489678-b5c09b8d-458b-41bf-9e74-5290fad392e9.png)
istället för så här:
![image](https://user-images.githubusercontent.com/52171526/143489777-b42cd3af-d555-4703-bc7c-85b8c007a618.png)

Jag tycker att den med gul textskugga inte ser särskilt bra ut och att den utan ser mer modern ut.