### PR TITLE
Add 'more event' button and adjust logic

### DIFF
--- a/src/components/Frontpage/index.js
+++ b/src/components/Frontpage/index.js
@@ -126,7 +126,7 @@ const Frontpage = ({ location, lang }) =>
                 {
                   (content && content.length)
                   ? content
-                    .filter((_, i) => i < 5)
+                    .filter((_, i) => i < 4)
                     .map(item => <li key={item.id}>
                       <Link
                           to={ lang === 'en' ? `/en/news/${item.id}` : `/nyheter/${item.id}` }
@@ -164,6 +164,20 @@ const Frontpage = ({ location, lang }) =>
                     </h4>
                 }
               </ul>
+              {
+                content.length > 4 &&
+                <div className="text-center">
+                  <Link
+                    to={ lang === 'en' ? '/en/news?itemType=EVENT' : '/nyheter?itemType=EVENT' }
+                    className={cx('more-btn')}
+                  >
+                    <Translate>
+                      <English>More Events »</English>
+                      <Swedish>Mer Event »</Swedish>
+                    </Translate>
+                  </Link>
+                </div>
+              }
             </div>
           }
         </Calypso>


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

Adds 'More Events' button to mirror 'More News', and fixes the event filtering (posts were being filtered down to 5 upcoming events instead of 4.) 

Fixes #30 