### PR TITLE
Add navbar sorting based on sort tag

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -12,7 +12,13 @@ import { LanguageContext } from './Translate'
 
 import './App.css'
 
-const createLinks = nav => nav.map(({ slug, title }) => <Link key={slug} to={slug}>{title}</Link>)
+const createLinks = nav => nav
+  .sort((a, b) => {
+    if (a.sort === undefined) return b.sort === undefined ? 0 : 1;
+    if (b.sort === undefined) return -1;
+    return a.sort - b.sort;
+  })
+  .map(({ slug, title }) => <Link key={slug} to={slug}>{title}</Link>)
 
 const renderMethone = path =>
   <Taitan pathname={path}>

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -7,17 +7,14 @@ import Frontpage from './Frontpage'
 import News from './News'
 import SingleNews from './News/SingleNews'
 import Default from './Default'
+import { comparePages } from '../utility/compare'
 
 import { LanguageContext } from './Translate'
 
 import './App.css'
 
 const createLinks = nav => nav
-  .sort((a, b) => {
-    if (a.sort === undefined) return b.sort === undefined ? 0 : 1;
-    if (b.sort === undefined) return -1;
-    return a.sort - b.sort;
-  })
+  .sort(comparePages)
   .map(({ slug, title }) => <Link key={slug} to={slug}>{title}</Link>)
 
 const renderMethone = path =>

--- a/src/components/Default/index.js
+++ b/src/components/Default/index.js
@@ -5,6 +5,7 @@ import { Title } from 'react-head'
 import Taitan from '../Taitan'
 import ErrorPage from '../ErrorPage'
 import { Translate, English, Swedish } from '../Translate'
+import { comparePages } from '../../utility/compare'
 
 const getNav = (nav, lang) => {
   const enNav = lang === 'en' ? nav.find(item => item.slug === '/en').nav : nav
@@ -16,11 +17,7 @@ const getNav = (nav, lang) => {
 const parseNav = (items, slug) =>
   <ul key={slug}>
     {items
-      .sort((a,b) => {
-        if (a.sort === undefined) return b.sort === undefined ? 0 : 1;
-        if (b.sort === undefined) return -1;
-        return a.sort - b.sort;
-      })
+      .sort(comparePages)
       .map(item =>
         <Fragment key={item.slug}>
           <li>

--- a/src/components/Default/index.js
+++ b/src/components/Default/index.js
@@ -15,19 +15,25 @@ const getNav = (nav, lang) => {
 
 const parseNav = (items, slug) =>
   <ul key={slug}>
-    { items.map(item =>
-      <Fragment key={item.slug}>
-        <li>
-          <Link
-            className={item.active ? 'text-theme-color strong' : ''}
-            to={item.slug}
-          >
-            { item.title }
-          </Link>
-        </li>
-        {item.nav && parseNav(item.nav, item.slug + '/')}
-      </Fragment>
-    )}
+    {items
+      .sort((a,b) => {
+        if (a.sort === undefined) return b.sort === undefined ? 0 : 1;
+        if (b.sort === undefined) return -1;
+        return a.sort - b.sort;
+      })
+      .map(item =>
+        <Fragment key={item.slug}>
+          <li>
+            <Link
+              className={item.active ? 'text-theme-color strong' : ''}
+              to={item.slug}
+            >
+              { item.title }
+            </Link>
+          </li>
+          {item.nav && parseNav(item.nav, item.slug + '/')}
+        </Fragment>
+      )}
   </ul>
 
 export const Default = ({ location, lang }) =>

--- a/src/utility/compare.js
+++ b/src/utility/compare.js
@@ -1,0 +1,17 @@
+// function for comparing two index tree nodes, used for sorting them in navigation tools (navbar/sidebar)
+// if an explicit ordering is defined, that is used, otherwise the title of the pages are used
+// a node with an ordering index is always prioritized over one without it.
+export const comparePages = (a, b) => {
+  if (a.sort === b.sort) {
+    if (a.title === b.title) return 0
+    if (a.title === undefined) return 1;
+    if (b.title === undefined) return -1;
+
+    return a.title.localeCompare(b.title) // the comparison ignores case
+  }
+
+  if (a.sort === undefined) return 1;
+  if (b.sort === undefined) return -1;
+
+  return a.sort - b.sort;
+}

--- a/src/utility/compare.js
+++ b/src/utility/compare.js
@@ -7,7 +7,7 @@ export const comparePages = (a, b) => {
     if (a.title === undefined) return 1;
     if (b.title === undefined) return -1;
 
-    return a.title.localeCompare(b.title) // the comparison ignores case
+    return a.title.localeCompare(b.title, 'sv-SE') // the comparison ignores case
   }
 
   if (a.sort === undefined) return 1;
@@ -15,3 +15,4 @@ export const comparePages = (a, b) => {
 
   return a.sort - b.sort;
 }
+


### PR DESCRIPTION
Sorts navbar items by the Sort-tag, if available.

Depends on [taitan#22](https://github.com/datasektionen/taitan/pull/22), but should work ~~as before~~ without it.