### PR TITLE
Add localhost razzle taitan url to published package

### DIFF
--- a/.github/workflows/deploy-docker-image.yml
+++ b/.github/workflows/deploy-docker-image.yml
@@ -1,4 +1,4 @@
-name: "Publish to ghcr.io"
+name: "Publish quick-setup image to ghcr.io"
 on:
   push:
     branches: [master]
@@ -29,6 +29,9 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
+          build-args:
+            - RAZZLE_TAITAN_URL=http://localhost:5000
+
           push: true
           tags: ${{ env.latest }},${{ env.current }}
           cache-from: type=gha


### PR DESCRIPTION
Purpose is to enable quick startup for local editing of `bawang-content`.

I don't really see a point for publishing a container for some other use case, especially since you have to set `RAZZLE_TAITAN_URL` during build anyway. So I think it is fine to change the existing publishing script.

Note that I'm not 100% sure that `build-args` will work, but based on the name and documentation it seems like it should be the correct thing: https://github.com/docker/build-push-action#customizing