### PR TITLE
Add sidebar title, and refactor taitan file to be actually readable

### DIFF
--- a/src/components/Default/index.js
+++ b/src/components/Default/index.js
@@ -7,9 +7,12 @@ import ErrorPage from '../ErrorPage'
 import { Translate, English, Swedish } from '../Translate'
 import { comparePages } from '../../utility/compare'
 
-const getNav = (nav, lang) => {
-  const enNav = lang === 'en' ? nav.find(item => item.slug === '/en').nav : nav
-  const child = enNav.find(item => item.nav)
+const getNavForLanguage = (nav, lang) => {
+  return lang === 'en' ? nav.find(item => item.slug === '/en').nav : nav
+}
+
+const getPageNav = (nav) => {
+  const child = nav.find(item => item.nav)
   if(child && child.nav) return child.nav
   return []
 }
@@ -46,9 +49,8 @@ const getRightSidebarListItemStyle = (headerLevel) => {
 }
 
 const getActiveMainTabTitle = (nav) => {
-  console.log(nav)
   for (const item of nav) {
-    if (item.expanded) {
+    if (item.expanded || item.active) {
       return item.title;
     }
   }
@@ -86,15 +88,15 @@ const taitanRenderer = (location, lang) => ({ title, body, sidebar, nav, anchors
     </header>
   );
   
-  const actualNav = !nav ? [] : nav;
-
+  // without this check, the page crashes due to the rendering the page before the taitan request is finished
+  const languageNav = !nav ? [] : getNavForLanguage(nav, lang);
   const LeftSidebar = () => (
     <div className="col-sm-4 col-md-3">
       <h2> 
-        {getActiveMainTabTitle(actualNav)}
+        {getActiveMainTabTitle(languageNav)}
       </h2>
       <div id="secondary-nav">
-        { parseNav(getNav(actualNav)) }
+        { parseNav(getPageNav(languageNav)) }
       </div>
     </div>
   );

--- a/src/components/Default/index.js
+++ b/src/components/Default/index.js
@@ -45,90 +45,109 @@ const getRightSidebarListItemStyle = (headerLevel) => {
   }
 }
 
-export const Default = ({ location, lang }) =>
-<Taitan pathname={location.pathname}>
-  {({ title, body, sidebar, nav, anchors }, error) =>
-    error ? <ErrorPage error={error} />
-    : <Fragment>
-      <Title>
-        { title + ' - Konglig Datasektionen'}
-      </Title>
-      <header key="header">
-        <div className="header-inner">
-          <div className="row">
-            <div className="header-left col-md-2">
-              <Link to="/">
-                {'« '}
-                <Translate>
-                  <English>Back</English>
-                  <Swedish>Tillbaka</Swedish>
-                </Translate>
-              </Link>
-            </div>
-            <div className="col-md-8">
-              <h2>{ title }</h2>
-            </div>
-            <div className="header-right col-md-2">
-              <a className="primary-action" href={"https://github.com/datasektionen/bawang-content/tree/master/" + location.pathname}>
-                <Translate>
-                  <English>Edit</English>
-                  <Swedish>Redigera</Swedish>
-                </Translate>
-              </a>
-            </div>
+const taitanRenderer = (location, lang) => ({ title, body, sidebar, nav, anchors }, error) => {
+
+  const PageHeader = () => (
+    <header key="header">
+      <div className="header-inner">
+        <div className="row">
+          <div className="header-left col-md-2">
+            <Link to="/">
+              {'« '}
+              <Translate>
+                <English>Back</English>
+                <Swedish>Tillbaka</Swedish>
+              </Translate>
+            </Link>
+          </div>
+          <div className="col-md-8">
+            <h2>{ title }</h2>
+          </div>
+          <div className="header-right col-md-2">
+            <a className="primary-action" href={"https://github.com/datasektionen/bawang-content/tree/master/" + location.pathname}>
+              <Translate>
+                <English>Edit</English>
+                <Swedish>Redigera</Swedish>
+              </Translate>
+            </a>
           </div>
         </div>
-      </header>
-      <div id="content" key="content">
-        <div className="row">
-          <div className="col-sm-4 col-md-3">
-            <div id="secondary-nav">
-              { !nav ? [] : parseNav(getNav(nav, lang)) }
-            </div>
-          </div>
-          <div className="col-sm-8 col-md-9">
-            <div className="row">
-              <div
-                className="col-md-9"
-                dangerouslySetInnerHTML={{__html: body}}
-              />
-              <div
-                className="col-md-3"
-                id="sidebar"
-              >
-                { sidebar
-                  ? <div
-                      className="sidebar-card"
-                      dangerouslySetInnerHTML={{__html: sidebar}}
-                    />
-                  : false
-                }
-                <div className="sidebar-card">
-                  <h2>
-                    <Translate>
-                      <English>On this page</English>
-                      <Swedish>På den här sidan</Swedish>
-                    </Translate>
-                  </h2>
-                  <ul>
-                    {(anchors || []).map(anchor =>
-                      <li key={anchor.id} style={{"list-style-type": "none"}}>
-                        <a href={'#' + anchor.id}>
-                          <div style={getRightSidebarListItemStyle(anchor.level)}>
-                            { anchor.value }
-                          </div>
-                        </a>
-                      </li>
-                    )}
-                  </ul>
+      </div>
+    </header>
+  )
+
+  const LeftSidebar = () => (
+    <div className="col-sm-4 col-md-3">
+      <div id="secondary-nav">
+        { !nav ? [] : parseNav(getNav(nav, lang)) }
+      </div>
+    </div>
+  )
+  
+  const RightSidebar = () => (
+    <div
+      className="col-md-3"
+      id="sidebar"
+    >
+      { sidebar
+        ? <div
+            className="sidebar-card"
+            dangerouslySetInnerHTML={{__html: sidebar}}
+          />
+        : false
+      }
+      <div className="sidebar-card">
+        <h2>
+          <Translate>
+            <English>On this page</English>
+            <Swedish>På den här sidan</Swedish>
+          </Translate>
+        </h2>
+        <ul>
+          {(anchors || []).map(anchor =>
+            <li key={anchor.id} style={{"list-style-type": "none"}}>
+              <a href={'#' + anchor.id}>
+                <div style={getRightSidebarListItemStyle(anchor.level)}>
+                  { anchor.value }
                 </div>
+              </a>
+            </li>
+          )}
+        </ul>
+      </div>
+    </div>
+  )
+
+  return (
+    error ? 
+      <ErrorPage error={error} /> : 
+      <Fragment>
+        <Title>
+          { title + ' - Konglig Datasektionen'}
+        </Title>
+        <PageHeader />
+        <div id="content" key="content">
+          <div className="row">
+            <LeftSidebar />
+            <div className="col-sm-8 col-md-9">
+              <div className="row">
+                <div
+                  className="col-md-9"
+                  dangerouslySetInnerHTML={{__html: body}}
+                />
+                <RightSidebar />
               </div>
             </div>
           </div>
         </div>
-      </div>
-    </Fragment>
-  }
-</Taitan>
+      </Fragment>
+  )  
+}
+
+
+export const Default = ({ location, lang }) =>
+  <Taitan pathname={location.pathname}>
+    { taitanRenderer(location, lang) }
+  </Taitan>
 
 export default Default

--- a/src/components/Default/index.js
+++ b/src/components/Default/index.js
@@ -45,6 +45,16 @@ const getRightSidebarListItemStyle = (headerLevel) => {
   }
 }
 
+const getActiveMainTabTitle = (nav) => {
+  console.log(nav)
+  for (const item of nav) {
+    if (item.expanded) {
+      return item.title;
+    }
+  }
+  return null
+}
+
 const taitanRenderer = (location, lang) => ({ title, body, sidebar, nav, anchors }, error) => {
 
   const PageHeader = () => (
@@ -74,21 +84,23 @@ const taitanRenderer = (location, lang) => ({ title, body, sidebar, nav, anchors
         </div>
       </div>
     </header>
-  )
+  );
+  
+  const actualNav = !nav ? [] : nav;
 
   const LeftSidebar = () => (
     <div className="col-sm-4 col-md-3">
+      <h2> 
+        {getActiveMainTabTitle(actualNav)}
+      </h2>
       <div id="secondary-nav">
-        { !nav ? [] : parseNav(getNav(nav, lang)) }
+        { parseNav(getNav(actualNav)) }
       </div>
     </div>
-  )
+  );
   
   const RightSidebar = () => (
-    <div
-      className="col-md-3"
-      id="sidebar"
-    >
+    <div className="col-md-3" id="sidebar">
       { sidebar
         ? <div
             className="sidebar-card"
@@ -116,7 +128,7 @@ const taitanRenderer = (location, lang) => ({ title, body, sidebar, nav, anchors
         </ul>
       </div>
     </div>
-  )
+  );
 
   return (
     error ? 

--- a/src/components/Default/index.js
+++ b/src/components/Default/index.js
@@ -57,40 +57,39 @@ const getActiveMainTabTitle = (nav) => {
   return null
 }
 
-const taitanRenderer = (location, lang) => ({ title, body, sidebar, nav, anchors }, error) => {
-
-  const PageHeader = () => (
-    <header key="header">
-      <div className="header-inner">
-        <div className="row">
-          <div className="header-left col-md-2">
-            <Link to="/">
-              {'« '}
-              <Translate>
-                <English>Back</English>
-                <Swedish>Tillbaka</Swedish>
-              </Translate>
-            </Link>
-          </div>
-          <div className="col-md-8">
-            <h2>{ title }</h2>
-          </div>
-          <div className="header-right col-md-2">
-            <a className="primary-action" href={"https://github.com/datasektionen/bawang-content/tree/master/" + location.pathname}>
-              <Translate>
-                <English>Edit</English>
-                <Swedish>Redigera</Swedish>
-              </Translate>
-            </a>
-          </div>
+const PageHeader = ({title, location}) => (
+  <header key="header">
+    <div className="header-inner">
+      <div className="row">
+        <div className="header-left col-md-2">
+          <Link to="/">
+            {'« '}
+            <Translate>
+              <English>Back</English>
+              <Swedish>Tillbaka</Swedish>
+            </Translate>
+          </Link>
+        </div>
+        <div className="col-md-8">
+          <h2>{ title }</h2>
+        </div>
+        <div className="header-right col-md-2">
+          <a className="primary-action" href={"https://github.com/datasektionen/bawang-content/tree/master/" + location.pathname}>
+            <Translate>
+              <English>Edit</English>
+              <Swedish>Redigera</Swedish>
+            </Translate>
+          </a>
         </div>
       </div>
-    </header>
-  );
-  
+    </div>
+  </header>
+);
+
+const LeftSidebar = ({nav, lang}) => {
   // without this check, the page crashes due to the rendering the page before the taitan request is finished
   const languageNav = !nav ? [] : getNavForLanguage(nav, lang);
-  const LeftSidebar = () => (
+  return (
     <div className="col-sm-4 col-md-3">
       <h2> 
         {getActiveMainTabTitle(languageNav)}
@@ -99,64 +98,68 @@ const taitanRenderer = (location, lang) => ({ title, body, sidebar, nav, anchors
         { parseNav(getPageNav(languageNav)) }
       </div>
     </div>
-  );
-  
-  const RightSidebar = () => (
-    <div className="col-md-3" id="sidebar">
-      { sidebar
-        ? <div
-            className="sidebar-card"
-            dangerouslySetInnerHTML={{__html: sidebar}}
-          />
-        : false
-      }
-      <div className="sidebar-card">
-        <h2>
-          <Translate>
-            <English>On this page</English>
-            <Swedish>På den här sidan</Swedish>
-          </Translate>
-        </h2>
-        <ul>
-          {(anchors || []).map(anchor =>
-            <li key={anchor.id} style={{"list-style-type": "none"}}>
-              <a href={'#' + anchor.id}>
-                <div style={getRightSidebarListItemStyle(anchor.level)}>
-                  { anchor.value }
-                </div>
-              </a>
-            </li>
-          )}
-        </ul>
-      </div>
-    </div>
-  );
+  )
+}
 
-  return (
-    error ? 
-      <ErrorPage error={error} /> : 
-      <Fragment>
-        <Title>
-          { title + ' - Konglig Datasektionen'}
-        </Title>
-        <PageHeader />
-        <div id="content" key="content">
-          <div className="row">
-            <LeftSidebar />
-            <div className="col-sm-8 col-md-9">
-              <div className="row">
-                <div
-                  className="col-md-9"
-                  dangerouslySetInnerHTML={{__html: body}}
-                />
-                <RightSidebar />
+const RightSidebar = ({sidebar, anchors}) => (
+  <div className="col-md-3" id="sidebar">
+    { sidebar
+      ? <div
+          className="sidebar-card"
+          dangerouslySetInnerHTML={{__html: sidebar}}
+        />
+      : false
+    }
+    <div className="sidebar-card">
+      <h2>
+        <Translate>
+          <English>On this page</English>
+          <Swedish>På den här sidan</Swedish>
+        </Translate>
+      </h2>
+      <ul>
+        {(anchors || []).map(anchor =>
+          <li key={anchor.id} style={{"list-style-type": "none"}}>
+            <a href={'#' + anchor.id}>
+              <div style={getRightSidebarListItemStyle(anchor.level)}>
+                { anchor.value }
               </div>
+            </a>
+          </li>
+        )}
+      </ul>
+    </div>
+  </div>
+);
+
+const taitanRenderer = (location, lang) =>
+  ({ title, body, sidebar, nav, anchors }, error) =>
+  (error ?
+    <ErrorPage error={error} /> :
+    <Fragment>
+      <Title>
+        { title + ' - Konglig Datasektionen'}
+      </Title>
+      <PageHeader title={title} location={location}/>
+
+      <div id="content" key="content">
+        <div className="row">
+          <LeftSidebar nav={nav} lang={lang}/>
+
+          <div className="col-sm-8 col-md-9">
+            <div className="row">
+              <div
+                className="col-md-9"
+                dangerouslySetInnerHTML={{__html: body}}
+              />
+              <RightSidebar sidebar={sidebar} anchors={anchors}/>
             </div>
+
           </div>
         </div>
-      </Fragment>
-  )  
-}
+      </div>
+    </Fragment>
+  )
 
 
 export const Default = ({ location, lang }) =>


### PR DESCRIPTION
I thought that it was a bit of bad UI that we didn't display which tab you're on after you've selected something in the sub-menu.
![2024-03-28-21:35:11](https://github.com/datasektionen/bawang/assets/16057417/b44b8339-9819-4d43-9212-b10c9f49e7d2)

So instead of highlighting the selected tab, I added it as a header for the sub-menu:
![2024-03-28-21:37:56](https://github.com/datasektionen/bawang/assets/16057417/c3c39d96-afe1-45ea-9b51-b4ef10d66a85)


While doing this, I decided to refactor the whole taitan display component, so that it is actually readable. 