### PR TITLE
Retroactive event calendar

### DIFF
--- a/src/components/Calypso.js
+++ b/src/components/Calypso.js
@@ -41,7 +41,7 @@ function getCalypsoUrl(type, search, timeSpan) {
   return url.href;
 }
 
-export const Calypso = ({ type, search, children, ttl, defaultTimeSpan }) => {
+export const Calypso = ({ type, search, children, defaultTimeSpan }) => {
   const [timeSpan, setTimeSpan] = useState(defaultTimeSpan);
   const cacheKey = getCalypsoUrl(type, search, timeSpan);
 

--- a/src/components/Calypso.js
+++ b/src/components/Calypso.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import fetch from 'cross-fetch'
 
 import { DataLoader } from './DataLoader'
@@ -13,13 +13,57 @@ const calypsoFetcher = url =>
       console.error('Calypso error', err)
     })
 
-export const Calypso = ({ type, search, children, ttl }) =>
-  <DataLoader
-    cacheKey={`${RAZZLE_CALYPSO_URL}/${type || 'list'}${search || ''}`}
+function iso(date) {
+  let str = date.toISOString();
+  if (str.endsWith('Z')) {
+    return str.slice(0, -1);
+  }
+  return str;
+}
+
+/**
+ * Get the Calypso API URL to fetch from. If events are being fetched and a time
+ * span is set, events in that time span will be fetched. Otherwise, all future
+ * events will be returned.
+ * 
+ * @param {'list' | 'event'} type The type of post to fetch.
+ * @param {string} search Search part of the URL.
+ * @param {[Date, Date] | null} timeSpan The time span, or null for all future events.
+ */
+function getCalypsoUrl(type, search, timeSpan) {
+  if (!timeSpan || type !== 'event') {
+    return `${RAZZLE_CALYPSO_URL}/${type || 'list'}${search || ''}`;
+  }
+  const [startDate, endDate] = timeSpan;
+  const url = new URL(`https://calypso.datasektionen.se/api/event/span`);
+  url.searchParams.set('startDate', iso(startDate));
+  url.searchParams.set('endDate', iso(endDate));
+  return url.href;
+}
+
+export const Calypso = ({ type, search, children, ttl, defaultTimeSpan }) => {
+  const [timeSpan, setTimeSpan] = useState(defaultTimeSpan);
+  const cacheKey = getCalypsoUrl(type, search, timeSpan);
+
+  return <DataLoader
+    cacheKey={cacheKey}
     fetcher={calypsoFetcher}
     ttl={CALYPSO_CACHE_TTL}
   >
-    {({ data, loading, time }) => children(data) }
-  </DataLoader>
+    {({ data, loading, time }) => {
+      if (type === 'event') {
+        return children({
+          content: data,
+          loading,
+          time,
+          onUpdateTimeSpan(span) {
+            setTimeSpan(span);
+          }
+        });
+      }
+      return children(data);
+    }}
+  </DataLoader>;
+}
 
 export default Calypso

--- a/src/components/Calypso.js
+++ b/src/components/Calypso.js
@@ -35,7 +35,7 @@ function getCalypsoUrl(type, search, timeSpan) {
     return `${RAZZLE_CALYPSO_URL}/${type || 'list'}${search || ''}`;
   }
   const [startDate, endDate] = timeSpan;
-  const url = new URL(`https://calypso.datasektionen.se/api/event/span`);
+  const url = new URL(`${RAZZLE_CALYPSO_URL}/event/span`);
   url.searchParams.set('startDate', iso(startDate));
   url.searchParams.set('endDate', iso(endDate));
   return url.href;

--- a/src/components/Frontpage/index.js
+++ b/src/components/Frontpage/index.js
@@ -9,7 +9,7 @@ import { Translate, English, Swedish } from '../Translate'
 
 import styles from './Frontpage.module.css'
 import skold from './skold.svg'
-import EventCalendar from '../EventCalendar/index.jsx';
+import EventCalendar, { getWeekTimeSpan } from '../EventCalendar/index.jsx';
 import './FixMe.css'
 
 const cx = classNames.bind(styles)
@@ -127,7 +127,7 @@ const Frontpage = ({ location, lang }) =>
           {/* Events section */}
           <Calypso type='event'>
           {/* Given content from Calypso, populate the section with events information */}
-          {content => (
+          {({content}) => (
             <div className={cx('news')}>
               {/* Title */}
               <Link to={lang === 'en' ? '/en/news?itemType=EVENT' : '/nyheter?itemType=EVENT'}>
@@ -255,9 +255,16 @@ const Frontpage = ({ location, lang }) =>
           </h2>
 
           {/* Calendar */}
-          <Calypso type='event'>
+          <Calypso type='event' defaultTimeSpan={getWeekTimeSpan(new Date())}>
           {/* Given content from Calypso, populate the section with events information */}
-          {content => <EventCalendar events={content} location={location} lang={lang} />}
+          {({content, loading, onUpdateTimeSpan}) =>
+            <EventCalendar
+              events={loading ? [] : content}
+              location={location}
+              lang={lang}
+              onUpdateTimeSpan={onUpdateTimeSpan}
+            />
+          }
           </Calypso>
         </div>
 

--- a/src/components/News/index.js
+++ b/src/components/News/index.js
@@ -8,7 +8,7 @@ import styles from './News.module.css'
 import Calypso from '../Calypso'
 import { Translate, English, Swedish } from '../Translate'
 import NewsItem from './NewsItem'
-import EventCalendar from '../EventCalendar'
+import EventCalendar, { getWeekTimeSpan } from '../EventCalendar'
 
 if(global && !global.URLSearchParams) {
   global.URLSearchParams = require('url').URLSearchParams
@@ -73,9 +73,16 @@ export const News = ({ location, lang, match }) => {
           </h2>
 
           {/* Calendar */}
-          <Calypso type='event'>
+          <Calypso type='event' defaultTimeSpan={getWeekTimeSpan(new Date())}>
           {/* Given content from Calypso, populate the section with events information */}
-          {content => <EventCalendar events={content} location={location} lang={lang} />}
+          {({content, loading, onUpdateTimeSpan}) =>
+            <EventCalendar
+              events={loading ? [] : content}
+              location={location}
+              lang={lang}
+              onUpdateTimeSpan={onUpdateTimeSpan}
+            />
+          }
           </Calypso>
         </div>
 
@@ -174,7 +181,7 @@ export const News = ({ location, lang, match }) => {
                       </Translate>
                     </h2>
                     <Calypso type='event'>
-                      {content =>
+                      {({content}) =>
                         (content && content.length)
                           ? content
                             .filter((_, i) => i < 5)


### PR DESCRIPTION
It works, and can display events from weeks in the past and future. But the solution isn't the prettiest. It was a bit tricky to get the relative week numbers the calendar component uses to line up when the events change. The calendar component is now instead fed with events from only one week at the time, and then always displays the current `widgetWeekGroups` instead of calculating which events to show and not. It might also be perceived as slower when viewing future events as they are no longer reused and instead fetched per week.

Feel free to suggest or request changes!