### PR TITLE
Add classnames as dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "bawang",
       "dependencies": {
         "babel-preset-stage-0": "^6.24.1",
+        "classnames": "^2.5.1",
         "cross-fetch": "^2.2.6",
         "express": "^4.18.2",
         "is-in-browser": "^1.1.3",
@@ -3358,9 +3359,10 @@
       }
     },
     "node_modules/classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "babel-preset-stage-0": "^6.24.1",
+    "classnames": "^2.5.1",
     "cross-fetch": "^2.2.6",
     "express": "^4.18.2",
     "is-in-browser": "^1.1.3",


### PR DESCRIPTION
classnames is imported in the code without having it as a dependency, which creates errors when importing a local instance of Methone that also uses classnames.