### PR TITLE
Calendar scrolls on phone

### DIFF
--- a/src/components/Frontpage/Frontpage.module.css
+++ b/src/components/Frontpage/Frontpage.module.css
@@ -58,6 +58,7 @@
   top: -220px;
   box-shadow: 0 2px 5px rgba(0, 0, 0, .1);
   z-index: 21;
+  overflow: scroll;
 }
 
 .content.hero {

--- a/src/components/News/News.module.css
+++ b/src/components/News/News.module.css
@@ -24,6 +24,7 @@
   padding: 20px 50px;
   min-height: 0;
   z-index: 21;
+  overflow: scroll;
 }
 
 .metadata {


### PR DESCRIPTION
As the people who use a phone might know, the calendar does not fit in the website layout. Therefore I have made a band-aid fix to make it scroll instead of the entire page.