### PR TITLE
Make it so that headings are shown in full when you click on a link to them

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -11,3 +11,7 @@ h3, .cerise #content h3 {
 .pagination .disabled, .pagination .disabled a {
   color: #999 !important;
 }
+
+h1, h2, h3, h4, h5, h6 {
+  scroll-margin-top: 60px
+}

--- a/src/components/App.css
+++ b/src/components/App.css
@@ -12,6 +12,11 @@ h3, .cerise #content h3 {
   color: #999 !important;
 }
 
-h1, h2, h3, h4, h5, h6 {
+#content h1,
+#content h2,
+#content h3,
+#content h4,
+#content h5,
+#content h6 {
   scroll-margin-top: 60px
 }


### PR DESCRIPTION
Before this change, you would be scrolled to just below a title when clicking on it, now you will instead see the whole heading ([example](https://datasektionen.se/sektionen/hedersmedlem#medlemmar)). I've been annoyed by this for way too long :p

I practice I don't think we have any headers deeper than `h3`, but we support them in theory, so why not future-proof all the way to `h6`.

Apparently this css rule does not work on the default iPhone browser according to some link online? But i don't have an iphone so I can't test, and the index sidebar is basically useless on phone anyway.