### PR TITLE
Committee icons

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -11,3 +11,17 @@ h3, .cerise #content h3 {
 .pagination .disabled, .pagination .disabled a {
   color: #999 !important;
 }
+
+#secondary-nav a {
+  display: flex !important;
+  align-items: center;
+}
+
+.pageIcon {
+  display: inline-block;
+  width: 2em;
+  height: 2em;
+  margin: 0 0.5em;
+  padding: 0;
+  border-radius: 50%;
+}

--- a/src/components/App.css
+++ b/src/components/App.css
@@ -17,7 +17,7 @@ h3, .cerise #content h3 {
   align-items: center;
 }
 
-.pageIcon {
+.page-icon {
   display: inline-block;
   width: 2em;
   height: 2em;

--- a/src/components/Default/index.js
+++ b/src/components/Default/index.js
@@ -28,6 +28,7 @@ const parseNav = (items, lang, slug) => (
                 className={item.active ? 'text-theme-color strong' : ''}
                 to={addLangToUrl(item.slug, lang)}
               >
+                <img src={item.image} width="50" height="50" />
                 {item.title}
               </Link>
             }

--- a/src/components/Default/index.js
+++ b/src/components/Default/index.js
@@ -28,8 +28,10 @@ const parseNav = (items, lang, slug) => (
                 className={item.active ? 'text-theme-color strong' : ''}
                 to={addLangToUrl(item.slug, lang)}
               >
-                <img src={item.image} width="50" height="50" />
-                {item.title}
+                {item.image
+                  ? <img src={item.image} className="pageIcon" />
+                  : <div className="pageIcon"></div>}
+                <span>{item.title}</span>
               </Link>
             }
           </li>

--- a/src/components/Default/index.js
+++ b/src/components/Default/index.js
@@ -29,7 +29,7 @@ const parseNav = (items, lang, slug) => (
                 to={addLangToUrl(item.slug, lang)}
               >
                 {item.image
-                  ? <img src={item.image} className="pageIcon" />
+                  ? <img src={item.image} className="page-icon" />
                   : <div className="pageIcon"></div>}
                 <span>{item.title}</span>
               </Link>


### PR DESCRIPTION
Display image added to `meta.toml` for subpages. This will currently only be used for committee images.

Looks like this:
![image](https://github.com/user-attachments/assets/980509dc-336e-494d-af99-6f1be50f5894)

Do not merge before https://github.com/datasektionen/taitan/pull/36.