### PR TITLE
Remove icon indent elsewhere from /namnder

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -21,7 +21,7 @@ h3, .cerise #content h3 {
   display: inline-block;
   width: 2em;
   height: 2em;
-  margin: 0 0.5em;
+  margin-right: 0.5em;
   padding: 0;
   border-radius: 50%;
 }

--- a/src/components/Default/index.js
+++ b/src/components/Default/index.js
@@ -15,6 +15,14 @@ const getPageNav = (nav) => {
   return [];
 };
 
+const getLinkIcon = (item) => {
+  if (item.image)
+    return <img src={item.image} className="page-icon" />;
+  else if (item.slug.startsWith("/namnder"))
+    return <div className="page-icon"></div>;
+  return;
+};
+
 const parseNav = (items, lang, slug) => (
   <ul key={slug} style={{ marginBottom: "1em" }}>
     {items
@@ -28,9 +36,7 @@ const parseNav = (items, lang, slug) => (
                 className={item.active ? 'text-theme-color strong' : ''}
                 to={addLangToUrl(item.slug, lang)}
               >
-                {item.image
-                  ? <img src={item.image} className="page-icon" />
-                  : <div className="page-icon"></div>}
+                {getLinkIcon(item)}
                 <span>{item.title}</span>
               </Link>
             }

--- a/src/components/Default/index.js
+++ b/src/components/Default/index.js
@@ -18,13 +18,12 @@ const getPageNav = (nav) => {
 const getLinkIcon = (item) => {
   if (item.image)
     return <img src={item.image} className="page-icon" />;
-  else if (item.slug.startsWith("/namnder"))
-    return <div className="page-icon"></div>;
-  return;
+  return <div className="page-icon"></div>;
 };
 
-const parseNav = (items, lang, slug) => (
-  <ul key={slug} style={{ marginBottom: "1em" }}>
+const parseNav = (items, lang, slug) => {
+  const hasIcon = items.some(item => item.image);
+  return <ul key={slug} style={{ marginBottom: "1em" }}>
     {items
       .sort(comparePages)
       .map(item =>
@@ -36,7 +35,7 @@ const parseNav = (items, lang, slug) => (
                 className={item.active ? 'text-theme-color strong' : ''}
                 to={addLangToUrl(item.slug, lang)}
               >
-                {getLinkIcon(item)}
+                {hasIcon && getLinkIcon(item)}
                 <span>{item.title}</span>
               </Link>
             }
@@ -44,8 +43,8 @@ const parseNav = (items, lang, slug) => (
           {item.nav && parseNav(item.nav, lang, item.slug + '/')}
         </Fragment>
       )}
-  </ul>
-);
+  </ul>;
+};
 
 const getRightSidebarListItemStyle = (headerLevel) => {
   // smallest level is 1, but it since we don't display the list item dot,


### PR DESCRIPTION
        Having the space looks good on `/namnder`, I agree that we want it there. Optimal imo would be to keep the space for pages that contain pictures (i.e. `/namnder`) and not have the space for the rest. Maybe not the cleanest solution to code though.

_Originally posted by @Herkarl in https://github.com/datasektionen/bawang/issues/96#issuecomment-2751600968_

Keep in mind I just made a change to Aurora making all nav links consistently as thick whether there's an icon or not. (visible in these images)
            
![image](https://github.com/user-attachments/assets/9cadc7cb-e3b0-4685-990c-3b71d90b4306)
![image](https://github.com/user-attachments/assets/01201d56-45f1-4c24-9f91-93b2abcd1cbd)
